### PR TITLE
Remove PHPUnit dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,34 +2,13 @@ eyes.php
 =============
 Getting started
 ----------------
-1. Install Applitools sdk.php:
+1. Install Applitools sdk.php using [Composer](https://getcomposer.org/):
 
-	If you have installed phpunit, webdriver, selnium use:
+	```bash
+	composer require applitools/eyes.sdk.php:dev-master phpunit/phpunit
+	```
 	
-	```bash
-	composer require applitools/eyes.sdk.php:dev-master
-	```
-	Also use previous if you want to get the latest update.
-	   
-	   
-	If you don't have any installed packages create composer.json file:
-	   
-	```json
-	{
-		"require": {
-			"phpunit/phpunit": "5.0.*",
-			"facebook/webdriver": "dev-master",
-			"phpunit/phpunit-selenium": "^3.0",
-			"applitools/eyes.sdk.php": "dev-master"
-		}
-	}
-	```
-	   
-	And then run:
-	   
-	```bash
-	composer install
-	```
+	This will also install PHPUnit, which is necessary to run the example test bellow.
 
 2. Download and run selenium server.
 
@@ -37,42 +16,50 @@ Getting started
 3. Create test class.
 
 	As example SomeTest.php:
-	```php
-	<?php
-	class SomeTest extends PHPUnit_Framework_TestCase
-	{
-		protected $url = 'http://php.net'; //Example url
-		protected $webDriver;
-		   
-		public function setUp()
-		{
-			$capabilities = array(\WebDriverCapabilityType::BROWSER_NAME => 'chrome');
-			$this->webDriver = RemoteWebDriver::create('http://localhost:4444/wd/hub', $capabilities);
-		}
-		   
-		public function tearDown()
-		{
-			$this->webDriver->close();
-		}
-		   
-		public function testSearch()
-		{
-			$this->webDriver->get($this->url);
-			$eyes = new Eyes();
-			$eyes->setApiKey('---YOUR APPLITOOLS API KEY---');
-			$eyes->setHideScrollbars(true);
-			$eyes->setStitchMode("CSS");
-			$eyes->setForceFullPageScreenshot(true);
-			$appName = 'Example_app_name';
-			$testName = 'Example_test_name';
-			$eyes->open($this->webDriver, $appName, $testName, new RectangleSize(1024, 500));
-			$eyes->checkWindow("Example_tag_name");
-			$eyes->checkFrame(WebDriverBy::xpath("//*[@src=\"frame1.html\"]"), 3, "Elem_1");
-			$eyes->checkRegionInFrameBySelector(WebDriverBy::xpath("//*[@src=\"frame1.html\"]"), WebDriverBy::id("inner-frame-div"), 3, "Elem_1", true);
-			$eyes->close();
-		}
-	}
-	```
+    ```php
+    <?php
+
+    use Applitools\Eyes;
+    use Applitools\RectangleSize;
+    use Facebook\WebDriver\Remote\RemoteWebDriver;
+    use Facebook\WebDriver\Remote\WebDriverCapabilityType;
+    use Facebook\WebDriver\WebDriverBy;
+    use PHPUnit\Framework\TestCase;
+
+    class SomeTest extends TestCase
+    {
+        protected $url = 'http://php.net'; //Example url
+        /** @var RemoteWebDriver */
+        protected $webDriver;
+
+        public function setUp()
+        {
+            $capabilities = array(WebDriverCapabilityType::BROWSER_NAME => 'chrome');
+            $this->webDriver = RemoteWebDriver::create('http://localhost:4444/wd/hub', $capabilities);
+        }
+
+        public function tearDown()
+        {
+            $this->webDriver->close();
+        }
+
+        public function testSearch()
+        {
+            $this->webDriver->get($this->url);
+            $eyes = new Eyes();
+            $eyes->setApiKey('---YOUR APPLITOOLS API KEY---');
+            $eyes->setHideScrollbars(true);
+            $eyes->setStitchMode("CSS");
+            $eyes->setForceFullPageScreenshot(true);
+            $appName = 'Example_app_name';
+            $testName = 'Example_test_name';
+            $eyes->open($this->webDriver, $appName, $testName, new RectangleSize(1024, 500));
+            $eyes->checkWindow("Example_tag_name");
+            $eyes->checkFrame(WebDriverBy::xpath("//*[@src=\"frame1.html\"]"), 3, "Elem_1");
+            $eyes->close();
+        }
+    }
+    ```
 4. Run the test.
 
 	If class was created in the folder with eyes.sdk.php command should be:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
   "description": "A php sdk for Applitools",
   "keywords": ["webdriver", "Applitools", "php"],
   "homepage": "https://github.com/applitools/eyes.sdk.php",
-  "version": "0.1.0",
   "type": "library",
   "license": "Apache-2.0",
   "support": {
@@ -12,8 +11,8 @@
   },
   "require": {
     "php": ">=5.6.0",
-    "facebook/webdriver": "1.4.0",
-    "gregwar/image": "2.*"
+    "facebook/webdriver": "^1.4.0",
+    "gregwar/image": "^2.0"
   },
   "suggest": {
     "phpunit/phpunit": "To run your tests"
@@ -23,10 +22,10 @@
   },
   "autoload": {
     "classmap": [
-        "eyes.sdk.php",
-        "eyes.common.php",
-        "eyes.images.php",
-        "eyes.selenium.php"
+      "eyes.sdk.php",
+      "eyes.common.php",
+      "eyes.images.php",
+      "eyes.selenium.php"
     ]
-   }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,13 @@
   "require": {
     "php": ">=5.6.0",
     "facebook/webdriver": "1.4.0",
-    "gregwar/image": "2.*",
-    "phpunit/phpunit": "6.0"
+    "gregwar/image": "2.*"
+  },
+  "suggest": {
+    "phpunit/phpunit": "To run your tests"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^6.0"
   },
   "autoload": {
     "classmap": [
@@ -22,6 +27,6 @@
         "eyes.common.php",
         "eyes.images.php",
         "eyes.selenium.php"
-    ]   
+    ]
    }
 }


### PR DESCRIPTION
See #7. The PHPUnit is no longer a required dependency, however it is suggested during installation (and I added it to the example command in readme).

What do you think?