### PR TITLE
Do not suggest dev-master

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Applitools Eyes SDK For Selenium Php WebDriver
 
 1. Install Applitools sdk.php using Composer:
 
-	```bash
-    composer require applitools/eyes.sdk.php:dev-master phpunit/phpunit
+    ```bash
+    composer require applitools/eyes.sdk.php phpunit/phpunit
     ```
-    
+
     This will also install PHPUnit, which is necessary to run the example test bellow.
 
 2. Download and run selenium server.
@@ -26,4 +26,3 @@ Please check the applitools website for usage instructions:
 - Php Appium native example: https://applitools.com/resources/tutorial/appium/native_php#step-2
 
 - Php Appium web example: https://applitools.com/resources/tutorial/appium/php#step-2
-


### PR DESCRIPTION
Hi, 
readme suggest installing dev-master version via composer. But this is not a good idea, people should usually use proper version constraint. See [Why are unbound version constraints a bad idea?](https://getcomposer.org/doc/faqs/why-are-unbound-version-constraints-a-bad-idea.md) in Composer docs.