### PR TITLE
Rename php-webdriver package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   },
   "require": {
     "php": ">=7.2.0",
-    "facebook/webdriver": ">=1.7.1"
+    "php-webdriver/webdriver": ">=1.7.1"
   },
   "suggest": {
     "phpunit/phpunit": "To run your tests"


### PR DESCRIPTION
Php-webdriver package [has been renamed](https://github.com/php-webdriver/php-webdriver/issues/730#issuecomment-575601572) and the original is now marked as abandoned.