### PR TITLE
Adding native tests implementation to the PHP SDK

### DIFF
--- a/tests/eyes.selenium.php.tests/TestAndroidNative.php
+++ b/tests/eyes.selenium.php.tests/TestAndroidNative.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Applitools\Selenium;
+
+require_once('TestAppiumSetup.php');
+
+use Applitools\Region;
+use Applitools\Selenium\fluent\Target;
+use Facebook\WebDriver\Remote\DesiredCapabilities;
+
+class TestAndroidNative extends TestAppiumSetup
+{
+
+    /** @beforeClass */
+    public static function setUpClass()
+    {
+        self::$forceFullPageScreenshot = false;
+        self::$testSuitName = "AndroidNativeApp";
+        parent::setUpClass();
+    }
+
+    protected function setUp() : void
+    {
+        $capabilities = new DesiredCapabilities();
+        $capabilities->setCapability("browserName", "");
+        $capabilities->setCapability("deviceName", "Samsung Galaxy S9 WQHD GoogleAPI Emulator");
+        $capabilities->setCapability("platformName", "Android");
+        $capabilities->setCapability("platformVersion", "8.1");
+
+        // The original app from Appium github project.
+        $capabilities->setCapability("app", "http://appium.s3.amazonaws.com/ContactManager.apk");
+
+        $capabilities->setCapability("username", $_SERVER["SAUCE_USERNAME"]);
+        $capabilities->setCapability("accesskey", $_SERVER["SAUCE_ACCESS_KEY"]);
+
+        $this->desiredCapabilities = $capabilities;
+    }
+
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     * @throws \Exception
+     */
+    public function AndroidNativeApp_checkWindow()
+    {
+        $this->init("AndroidNativeApp checkWindow");
+        $this->eyes->check("", Target::window()->ignore(Region::CreateFromLTWH(1271, 0, 158, 100)));
+    }
+
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     * @throws \Exception
+     */
+    public function AndroidNativeApp_checkRegion()
+    {
+        $this->init("AndroidNativeApp checkRegionFloating");
+        $this->eyes->check("",
+            Target::region(Region::CreateFromLTWH(0, 100, 1400, 2000))
+                ->addFloatingRegion(Region::CreateFromLTWH(10, 10, 20, 20), 3, 3, 20, 30 )
+        );
+    }
+
+}

--- a/tests/eyes.selenium.php.tests/TestAppiumSetup.php
+++ b/tests/eyes.selenium.php.tests/TestAppiumSetup.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Applitools\Selenium;
+
+use Applitools\FileLogger;
+use Applitools\PrintLogHandler;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+
+require_once('TestSetup.php');
+require_once('TestDataProvider.php');
+
+abstract class TestAppiumSetup extends TestSetup
+{
+
+    private $logsPath = ".";
+
+    public function init($testName)
+    {
+        try {
+            $this->oneTimeSetUp();
+
+            if (!isset($_SERVER["CI"])) {
+                $date = date("Y_m_d H_i_s");
+
+                if (isset($_SERVER["APPLITOOLS_LOGS_PATH"])) {
+                    $this->logsPath = $_SERVER["APPLITOOLS_LOGS_PATH"];
+                }
+
+                $logPath = $this->logsPath . DIRECTORY_SEPARATOR . "PHP" . DIRECTORY_SEPARATOR . "$testName $date";
+                $logFilename = $logPath . DIRECTORY_SEPARATOR . "log.log";
+                $this->eyes->setLogHandler(new FileLogger($logFilename, false, true));
+                $this->eyes->setSaveDebugScreenshots(true);
+                $this->eyes->setDebugScreenshotsPath($logPath);
+                $this->eyes->setDebugScreenshotsPrefix($testName);
+            } else {
+                $this->eyes->setLogHandler(new PrintLogHandler(true));
+            }
+
+            $this->eyes->getLogger()->log("Test $testName starting...");
+            if (isset($_SERVER['SELENIUM_SERVER_URL'])) {
+                $seleniumServerUrl = $_SERVER['SELENIUM_SERVER_URL'];
+            } else {
+                $seleniumServerUrl="http://ondemand.saucelabs.com/wd/hub";
+            }
+            $this->desiredCapabilities->setCapability("name", "$testName ({$this->eyes->getFullAgentId()})");
+            $this->eyes->getLogger()->log("Creating remote web driver. Server URL: $seleniumServerUrl.");
+            $this->driver = RemoteWebDriver::create($seleniumServerUrl, $this->desiredCapabilities,null, 240000);
+          
+            $this->eyes->setBatch(TestDataProvider::$BatchInfo);
+
+            $this->eyes->setScaleRatio($this->scaleRatio);
+            $this->eyes->open($this->driver, self::$testSuitName, $testName);
+        } catch (\Facebook\WebDriver\Exception\SessionNotCreatedException $sncEx) {
+            throw $sncEx;
+        } catch(\Exception $ex) {
+            print $ex->getMessage();
+        }
+    }
+}

--- a/tests/eyes.selenium.php.tests/TestIOSNative.php
+++ b/tests/eyes.selenium.php.tests/TestIOSNative.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Applitools\Selenium;
+
+require_once('TestAppiumSetup.php');
+
+use Applitools\Region;
+use Applitools\Selenium\fluent\Target;
+use Facebook\WebDriver\Remote\DesiredCapabilities;
+
+class TestIOSNative extends TestAppiumSetup
+{
+
+    /** @beforeClass */
+    public static function setUpClass()
+    {
+        self::$forceFullPageScreenshot = false;
+        self::$testSuitName = "AndroidNativeApp";
+        parent::setUpClass();
+    }
+
+    protected function setUp() : void
+    {
+        $capabilities = new DesiredCapabilities();
+        $capabilities->setCapability("browserName", "");
+        $capabilities->setCapability("deviceName", "iPhone XS Simulator");
+        $capabilities->setCapability("platformName", "iOS");
+        $capabilities->setCapability("platformVersion", "12.2");
+
+        // The original app from Appium github project.
+        $capabilities->setCapability("app", "https://applitools.bintray.com/Examples/HelloWorldiOS_1_0.zip");
+
+        $capabilities->setCapability("username", $_SERVER["SAUCE_USERNAME"]);
+        $capabilities->setCapability("accesskey", $_SERVER["SAUCE_ACCESS_KEY"]);
+
+        $this->desiredCapabilities = $capabilities;
+    }
+
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     * @throws \Exception
+     */
+    public function IOSNativeApp_checkWindow()
+    {
+        $this->init("iOSNativeApp checkWindow");
+        $this->eyes->check("", Target::window()->ignore(Region::CreateFromLTWH(0, 0, 300, 100)));
+    }
+
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     * @throws \Exception
+     */
+    public function IOSNativeApp_checkRegion()
+    {
+        $this->init("iOSNativeApp checkRegionFloating");
+        $this->eyes->check("",
+            Target::region(Region::CreateFromLTWH(0, 100, 375, 712))
+                ->addFloatingRegion(Region::CreateFromLTWH(10, 10, 20, 20), 3, 3, 20, 30 )
+        );
+    }
+
+}


### PR DESCRIPTION
Implementation of the appium native tests for the PHP SDK
Also tests are failing due to issue with SDK. During the native mobile runs an error is displayed 
Facebook\WebDriver\Exception\UnknownServerException: Method is not implemented
As others tests iOS native is extremely slow, require more 10 min timeouts on SauceLabs ((